### PR TITLE
Add total package count to status page overview

### DIFF
--- a/eln-check.py
+++ b/eln-check.py
@@ -303,6 +303,7 @@ if __name__ == "__main__":
       count_same = counter_same,
       count_old = counter_old,
       count_none = counter_none,
+      count_total = counter_same + counter_old + counter_none,
       packages = package_list
       ))
     w.close()

--- a/status.html.jira
+++ b/status.html.jira
@@ -22,6 +22,7 @@
       <tr><td bgcolor="#00FF00">SAME</td><td>{{ count_same }}</td><td>Rawhide and ELN builds are caught up</td></tr>
       <tr><td bgcolor="#FFFFCC">OLD</td><td>{{ count_old }}</td><td>ELN build is older than Rawhides</td></tr>
       <tr><td bgcolor="#FF0000">NONE</td><td>{{ count_none }}</td><td>There is no ELN build</td></tr>
+      <tr><td>TOTAL</td><td>{{ count_total }}</td><td>Total ELN packages</td></tr>
     </table>
     <h2>Details</h2>
     <table border=1 style=width:100%>


### PR DESCRIPTION
Every time I look at the status page, I find myself trying to add up the total number in my head--so why not add it to the overview?
