### PR TITLE
Add percentages to results

### DIFF
--- a/Jenkinsfile
+++ b/Jenkinsfile
@@ -12,6 +12,7 @@ def dataFile = 'to_rebuild.txt'
 def untagFile = 'to_untag.txt'
 def statusFile = 'status.txt'
 def statusRenderedFile = 'status.html'
+def successrateFile = 'successrate.txt'
 
 pipeline {
     agent {
@@ -47,7 +48,7 @@ pipeline {
     stages {
 	stage('Collect stats') {
 	    steps {
-		sh "./eln-check.py -o $dataFile -s $statusFile -u $untagFile"
+		sh "./eln-check.py -o $dataFile -s $statusFile -u $untagFile -r $successrateFile"
 	    }
 	}
 	stage('Trigger builds') {
@@ -84,7 +85,7 @@ pipeline {
     }
     post {
 	success {
-	    archiveArtifacts artifacts: "$dataFile,$statusFile,$statusRenderedFile,$untagFile"
+	    archiveArtifacts artifacts: "$dataFile,$statusFile,$statusRenderedFile,$untagFile,$successrateFile"
 	}
     }
 }

--- a/eln-check.py
+++ b/eln-check.py
@@ -168,6 +168,10 @@ if __name__ == "__main__":
                         help="Filepath for the untag list",
                         default="untag.txt"
     )
+    parser.add_argument("-r", "--successrate",
+                        help="Filepath for the success rate percentage webpage",
+                        default="successrate.txt"
+    )
 
     args = parser.parse_args()
 
@@ -297,13 +301,29 @@ if __name__ == "__main__":
         this_package['color'] = color_none
         counter_none += 1
       package_list.append(this_package)
+    counter_total = counter_same + counter_old + counter_none
+    if counter_total == 0:
+        percentage_same = "?%"
+        percentage_old = "?%"
+        percentage_none = "?%"
+    else:
+        percentage_same = "{:.2%}".format(counter_same / counter_total)
+        percentage_old = "{:.2%}".format(counter_old / counter_total)
+        percentage_none = "{:.2%}".format(counter_none / counter_total)
     w = open(args.webpage,'w')
     w.write(tmpl.render(
       this_date = datetime.datetime.now().strftime('%Y-%m-%d %H:%M'),
       count_same = counter_same,
+      percent_same = percentage_same,
       count_old = counter_old,
+      percent_old = percentage_old,
       count_none = counter_none,
-      count_total = counter_same + counter_old + counter_none,
+      percent_none = percentage_none,
+      count_total = counter_total,
       packages = package_list
       ))
     w.close()
+
+    r = open(args.successrate,'w')
+    r.write("{0}\n".format(percentage_same))
+    r.close()

--- a/status.html.jira
+++ b/status.html.jira
@@ -19,10 +19,30 @@
     <p>Page updated: {{ this_date }}
     <h2>Overview</h2>
     <table border=0>
-      <tr><td bgcolor="#00FF00">SAME</td><td>{{ count_same }}</td><td>Rawhide and ELN builds are caught up</td></tr>
-      <tr><td bgcolor="#FFFFCC">OLD</td><td>{{ count_old }}</td><td>ELN build is older than Rawhides</td></tr>
-      <tr><td bgcolor="#FF0000">NONE</td><td>{{ count_none }}</td><td>There is no ELN build</td></tr>
-      <tr><td>TOTAL</td><td>{{ count_total }}</td><td>Total ELN packages</td></tr>
+      <tr>
+        <td bgcolor="#00FF00">SAME</td>
+        <td style="text-align:right">{{ count_same }}</td>
+        <td style="text-align:right">{{ percent_same }}</td>
+        <td>Rawhide and ELN builds are caught up</td>
+      </tr>
+      <tr>
+        <td bgcolor="#FFFFCC">OLD</td>
+        <td style="text-align:right">{{ count_old }}</td>
+        <td style="text-align:right">{{ percent_old }}</td>
+        <td>ELN build is older than Rawhides</td>
+      </tr>
+      <tr>
+        <td bgcolor="#FF0000">NONE</td>
+        <td style="text-align:right">{{ count_none }}</td>
+        <td style="text-align:right">{{ percent_none }}</td>
+        <td>There is no ELN build</td>
+      </tr>
+      <tr>
+        <td>TOTAL</td>
+        <td style="text-align:right">{{ count_total }}</td>
+        <td style="text-align:right">100.00%</td>
+        <td>Total ELN packages</td>
+      </tr>
     </table>
     <h2>Details</h2>
     <table border=1 style=width:100%>


### PR DESCRIPTION
Add percentage column to the build status overview table.

Also write just the success rate percentage to a file so it can be included on a dashboard page.

(Added at the request of Rui.)